### PR TITLE
Use TxbitResponse as return object from all functions

### DIFF
--- a/txbit/tests/test.py
+++ b/txbit/tests/test.py
@@ -66,7 +66,17 @@ class TestTxbit(unittest.TestCase):
         res = Txbit.getMarketHistory('BAN/BTC')
         self.assertTrue(res.success)
 
+    def test_getSystemStatus(self):
+        res = Txbit.getSystemStatus()
+        self.assertTrue(res.success)
 
+    def test_getCurrencyInformation(self):
+        res = Txbit.getCurrencyInformation('BTC')
+        self.assertTrue(res.success)
+
+    def test_getCurrencyBalanceSheet(self):
+        res = Txbit.getCurrencyBalanceSheet('BTC')
+        self.assertTrue(res.success)
 
 if __name__ == '__main__':
     unittest.main()

--- a/txbit/txbit.py
+++ b/txbit/txbit.py
@@ -86,13 +86,13 @@ class Txbit:
 
     def getCurrencyInformation(currency):
         params = { 'currency': currency}
-        res = Txbit.request('public/getcurrencyinformation')
+        res = Txbit.request('public/getcurrencyinformation', params)
         result = { currency: res.json()['result'] } if res.json()['success'] else res.status_code
         return TxbitResponse(res.ok and res.json()['success'], "", result)
 
     def getCurrencyBalanceSheet(currency):
         params = { 'currency': currency}
-        res = Txbit.request('public/getcurrencybalancesheet')
+        res = Txbit.request('public/getcurrencybalancesheet', params)
         result = { currency: res.json()['result'] } if res.json()['success'] else res.status_code
         return TxbitResponse(res.ok and res.json()['success'], "", result)
 


### PR DESCRIPTION
slight refactor to use TxbitResponse as the common return object between all API calls, and adds tests for all Public API functions. This leaves error handling and reporting to each individual function